### PR TITLE
Fix link issues

### DIFF
--- a/docs/09-operations/01-devsecops.md
+++ b/docs/09-operations/01-devsecops.md
@@ -20,8 +20,8 @@ It then explains and illustrates various vulnerability scanning steps commonly u
 * Dynamic Application Security Testing ([DAST][dsodast])
 * Interactive Application Security Testing ([IAST][dsoiast])
 * Software Composition Analysis ([SCA][dsosca])
-* [Infrastructure Vulnerability Scanning][dsocvs]
-* [Container Vulnerability Scanning][dsoivs]
+* [Infrastructure Vulnerability Scanning][dsoivs]
+* [Container Vulnerability Scanning][dsocvs]
 
 The DevSecOps Guideline is a concise guide that provides the foundational knowledge to implement DevSecOps.
 


### PR DESCRIPTION
Infrastructure vulnerability scanning is linked to Container vulnerability scanning and vica versa. This commit is a fix for that.

**Summary** :  
This is just some cleanup, nothin noteworthy
Just fixing a small mishap where links two links are changed, and they redirect to the wrong page.

**Description for the changelog** :  
Fix links for Infrastructure Vulnerability scanning and Container Vulnerability scanning


**Declaration**:

- [x] content meets the [license](../license.txt) for this project
- [x] AI has not been used, or has been declared, in this pull request

**Other info** :  
<!-- Add here any other information that may be of help to the reviewer -->

Thanks for submitting a pull request!

Please make sure you follow our [Code of Conduct](../code_of_conduct.md)
and our [contributing guidelines](../contributing.md)

Automated tests are run to check links, markdown and spelling

The pull request must pass these tests before it can be merged
