### PR TITLE
update links to BLT and CVE sites

### DIFF
--- a/docs/en/05-implementation/02-dependencies/01-dependency-check.md
+++ b/docs/en/05-implementation/02-dependencies/01-dependency-check.md
@@ -71,7 +71,7 @@ then [submit an issue][issue070201] or [edit on GitHub][edit070201].
 [adoptium]: https://adoptium.net/
 [cpe]: https://nvd.nist.gov/products/cpe
 [cscicd]: https://cheatsheetseries.owasp.org/cheatsheets/CI_CD_Security_Cheat_Sheet
-[cve]: https://cve.mitre.org/
+[cve]: https://www.cve.org/
 [depcheck]: https://owasp.org/www-project-dependency-check/
 [depcheck-docs]: https://jeremylong.github.io/DependencyCheck/
 [depcheck-download]: https://github.com/jeremylong/DependencyCheck/releases

--- a/docs/en/05-implementation/02-dependencies/index.md
+++ b/docs/en/05-implementation/02-dependencies/index.md
@@ -24,7 +24,7 @@ Having an SBOM provides the ability to quickly find out which applications are a
 The OWASP Developer Guide is a community effort; if there is something that needs changing
 then [submit an issue][issue0702] or [edit on GitHub][edit0702].
 
-[cve]: https://cve.mitre.org/
+[cve]: https://www.cve.org/
 [edit0702]: https://github.com/OWASP/DevGuide/blob/main/docs/es/05-implementation/02-dependencies/index.md
 [issue0702]: https://github.com/OWASP/DevGuide/issues/new?labels=enhancement&template=request.md&title=Update:%2005-implementation/02-dependencies/index
 [sammi]: https://owaspsamm.org/model/implementation/

--- a/docs/en/11-security-gap-analysis/02-blt.md
+++ b/docs/en/11-security-gap-analysis/02-blt.md
@@ -41,7 +41,7 @@ then [submit an issue][issue1302] or [edit on GitHub][edit1302].
 [bltchrome]: https://github.com/OWASP/BLT-Extension
 [bltcore]: https://github.com/OWASP/BLT
 [bltapp]: https://github.com/OWASP/BLT-Flutter
-[bltsite]: https://blt.owasp.org/
+[bltsite]: https://owaspblt.org/
 [csdisclose]: https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet
 [edit1302]: https://github.com/OWASP/DevGuide/blob/main/docs/en/11-security-gap-analysis/02-blt.md
 [issue1302]: https://github.com/OWASP/DevGuide/issues/new?labels=content&template=request.md&title=Update:%2011-security-gap-analysis/02-blt

--- a/docs/en/12-appendices/02-verification-dos-donts/03-open-source-software.md
+++ b/docs/en/12-appendices/02-verification-dos-donts/03-open-source-software.md
@@ -20,7 +20,7 @@ We realize it could be challenging, but if feasible, maintain a list of approved
   * Where possible use version pinning
   * Where possible use integrity verification
   * Check for vulnerabilities for the selected binaries in vulnerability disclosure databases like
-    * CVE database (`https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=bouncy+castle`)
+    * CVE database (`https://www.cve.org/CVERecord/SearchResults?query=bouncy+castle`)
     * VulnDB (`https://vuldb.com/?id.173918`)
   * If within the budget of your organization, use an SCA tool to scan for vulnerabilities
   * Always vet and perform due-diligence on third-party modules that you install
@@ -84,7 +84,7 @@ We realize it could be challenging, but if feasible, maintain a list of approved
   * Lock files
   * Monitor vulnerabilities with:
     * Check for vulnerabilities for the selected binaries in vulnerability disclosure databases like
-      * CVE database (`https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=bouncy+castle`)
+      * CVE database (`https://www.cve.org/CVERecord/SearchResults?query=bouncy+castle`)
       * VulnDB (`https://vuldb.com/?id.173918`)
   * If within the budget of your organization, use an SCA tool to scan for vulnerabilities
 

--- a/docs/es/05-implementation/02-dependencies/01-dependency-check.md
+++ b/docs/es/05-implementation/02-dependencies/01-dependency-check.md
@@ -78,7 +78,7 @@ si hay algo que necesita cambiarse entonces [cree un issue][issue070201] o [edí
 [adoptium]: https://adoptium.net/
 [cpe]: https://nvd.nist.gov/products/cpe
 [cscicd]: https://cheatsheetseries.owasp.org/cheatsheets/CI_CD_Security_Cheat_Sheet
-[cve]: https://cve.mitre.org/
+[cve]: https://www.cve.org/
 [depcheck]: https://owasp.org/www-project-dependency-check/
 [depcheck-docs]: https://jeremylong.github.io/DependencyCheck/
 [depcheck-download]: https://github.com/jeremylong/DependencyCheck/releases

--- a/docs/es/05-implementation/02-dependencies/index.md
+++ b/docs/es/05-implementation/02-dependencies/index.md
@@ -26,7 +26,7 @@ Traducción de versión [original en inglés][en0702].
 La Guía del Desarrollador de OWASP es un esfuerzo comunitario;
 si ve algo que necesita cambios, entonces [cree un issue][issue0702] o [edítelo en GitHub][edit0702].
 
-[cve]: https://cve.mitre.org/
+[cve]: https://www.cve.org/
 [edit0702]: https://github.com/OWASP/DevGuide/blob/main/docs/es/05-implementation/02-dependencies/index.md
 [en0702]: https://devguide.owasp.org/en/05-implementation/02-dependencies/
 [issue0702]: https://github.com/OWASP/DevGuide/issues/new?labels=enhancement&template=request.md&title=Update:%2005-implementation/02-dependencies/index


### PR DESCRIPTION
**Summary** :  
Mitre's CVE site is now deprecated and this pull request moves the links to www.cve.org

**Description for the changelog** :  
update links to BLT and CVE sites

**Declaration**:

- [x] content meets the [license](../license.txt) for this project
- [x] AI has not been used, or has been declared, in this pull request

**Other info** :  
closes #106 

