### PR TITLE
Update 05-content-security-policy.md

### DIFF
--- a/docs/en/12-appendices/01-implementation-dos-donts/05-content-security-policy.md
+++ b/docs/en/12-appendices/01-implementation-dos-donts/05-content-security-policy.md
@@ -43,8 +43,6 @@ For web applications, the source of all content is set to self.
 
 - `default-src` 'self'
 - `script-src` 'self';
-- `script-src` `unsafe-inline` `unsafe-eval` https:; (I am fairly sure this is used to block unsafe inline scripts
-    and `eval` but to be checked) - Have checked now and `unsafe-inline` should not be used
 - `connect-src` 'self';
 - `img-src` 'self';
 - `style-src` 'self'


### PR DESCRIPTION
**Summary** :  

Section: [12-appendices/01-implementation-dos-donts/05-content-security-policy](https://github.com/OWASP/DevGuide/blob/main/docs/en/12-appendices/01-implementation-dos-donts/05-content-security-policy.md)

Implements #115

**Description for the changelog** :  

Remove lines 46 and 47.

**Declaration**:

- [x] content meets the [license](../license.txt) for this project
- [x] AI has not been used, or has been declared, in this pull request

**Other info** :  

This follows the invitation of providing a pull request by @jgadsden
