### PR TITLE
Pytm description fix

### DIFF
--- a/docs/en/04-design/01-threat-modeling/02-pytm.md
+++ b/docs/en/04-design/01-threat-modeling/02-pytm.md
@@ -9,7 +9,7 @@ Pytm is an OWASP Production Project with a community of contributors creating [r
 
 Pytm is a Python library that provides a programmatic way of threat modeling;
 the application model itself is defined as a python3 source file and follows Python program syntax.
-Findings are included in a templated threat modeling report.
+Findings are included in a template-defined threat modeling report.
 The threat file can be reused between projects and provides for accumulation of a knowledge base.
 
 Using pytm the model and threats can be programmatically output as a [dot][graphvizdot] data flow diagram

--- a/docs/es/04-design/01-threat-modeling/02-pytm.md
+++ b/docs/es/04-design/01-threat-modeling/02-pytm.md
@@ -6,7 +6,7 @@ El objetivo de pytm es realizar el modelado de amenazas Shift-Left, lo que signi
 el modelado ya en etapas tempranas del proyecto, haciendo que el modelado de amenazas sea más automatizado
 y centrado en el desarrollador.
 
-Pytm es un Proyecto de Producion de OWASP con una comunidad de colaboradores
+Pytm es un Proyecto de Producción de OWASP con una comunidad de colaboradores
 que crean [versiones regulares][pytmreleases].
 
 #### ¿Qué es pytm?


### PR DESCRIPTION
**Summary** :  

Fixing wrong Java library designation and clarifying output. 

**Description for the changelog** :  

Minor details fix. 

**Declaration**:

- [X ] content meets the [license](../license.txt) for this project
- [ X] AI has not been used, or has been declared, in this pull request

**Other info** :  

Translation verified with Google Translate.