### PR TITLE
Add links for Java Encoder and Java HTML Sanitizer

### DIFF
--- a/docs/en/05-implementation/03-secure-libraries/index.md
+++ b/docs/en/05-implementation/03-secure-libraries/index.md
@@ -8,6 +8,11 @@ and provide standardized technologies and frameworks that can be used throughout
 within the SAMM [Security Architecture][sammdsa] security practice
 which in turn is part of the [Design][sammd] business function.
 
+## Recommended Secure Libraries (OWASP Projects)
+
+- **OWASP Java Encoder** – https://owasp.org/www-project-java-encoder/
+- **OWASP Java HTML Sanitizer** – https://owasp.org/www-project-java-html-sanitizer/
+
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing


### PR DESCRIPTION
Fixes #181

Added links to OWASP Java Encoder and OWASP Java HTML Sanitizer in the secure libraries section, as suggested by maintainers.

**Summary**
Adds references to two OWASP secure libraries to improve discoverability.

**Description for the changelog**
Add links to OWASP Java Encoder and Java HTML Sanitizer.

**Declaration**
- [x] content meets the license for this project
- [x] I have read the contribution guide and agree to the Code of Conduct
- [x] Any use of AI is declared: I used AI only for guidance while preparing the contribution, but the actual content added consists solely of factual links.

**Other info**
N/A
