### PR TITLE
Add Java Encoder and Java HTML Sanitizer to secure libraries index

### DIFF
--- a/docs/en/05-implementation/03-secure-libraries/index.md
+++ b/docs/en/05-implementation/03-secure-libraries/index.md
@@ -10,6 +10,26 @@ which in turn is part of the [Design][sammd] business function.
 
 ----
 
+## Additional Secure Libraries
+
+### Java Encoder
+Java Encoder is an OWASP library that helps prevent cross-site scripting (XSS)
+by safely encoding untrusted data before it is included in application output.
+
+It should be used whenever user-controlled input is rendered in HTML,
+JavaScript, URLs, or other browser-facing contexts.
+
+See the OWASP Java Encoder project for details [javaencoder].
+
+### Java HTML Sanitizer
+Java HTML Sanitizer is an OWASP library designed to clean untrusted HTML content
+by allowing only safe elements and attributes.
+
+It is useful when applications need to accept HTML input from users while
+reducing the risk of XSS vulnerabilities.
+
+See the OWASP Java HTML Sanitizer project for details [htmlsanitizer].
+
 The OWASP Developer Guide is a community effort; if there is something that needs changing
 then [submit an issue][issue0703] or [edit on GitHub][edit0703].
 
@@ -18,3 +38,5 @@ then [submit an issue][issue0703] or [edit on GitHub][edit0703].
 [sammd]: https://owaspsamm.org/model/design/
 [sammdsa]: https://owaspsamm.org/model/design/secure-architecture/
 [sammdsatm]: https://owaspsamm.org/model/design/secure-architecture/stream-b/
+[javaencoder]: https://owasp.org/www-project-java-encoder/
+[htmlsanitizer]: https://owasp.org/www-project-java-html-sanitizer/


### PR DESCRIPTION
**Summary** :  

Fixes #181
Added short brief and links to OWASP Java Encoder and OWASP Java HTML Sanitizer in the secure libraries section.

**Description for the changelog** :  
This PR adds brief sections for Java Encoder and Java HTML Sanitizer to the secure libraries index.

**Declaration**:

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] any [use of AI](../blob/main/contributing.md#use-of-ai) has been declared in this pull request

**Other info** :  

<!-- Add here any other information that may be of help to the reviewer

Automated tests are run to check links, markdown and spelling
The pull request must pass these tests before it can be merged
-->
