### PR TITLE
update automation dependencies to use hashes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-# for security reasons the github actions are pinned to specific release versions
+# for security reasons the github actions are pinned to specific SHAs
 jobs:
   link_checker:
     name: Link checker
@@ -26,6 +26,7 @@ jobs:
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: >-
+            --verbose
             --no-progress
             --max-retries 1
             --retry-wait-time 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: >-
             --no-progress
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Lint markdown
-        uses: DavidAnson/markdownlint-cli2-action@v22.0.0
+        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
         with:
           config: '.markdownlint.yaml'
           globs: |
@@ -58,22 +58,22 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Spell check EN language
-        uses: rojopolis/spellcheck-github-actions@0.58.0
+        uses: rojopolis/spellcheck-github-actions@e3cd8e9aec4587ec73bc0e60745aafd45c37aa2e
         with:
           config_path: .spellcheck-en.yaml
 
       - name: Spell check ES language
-        uses: rojopolis/spellcheck-github-actions@0.58.0
+        uses: rojopolis/spellcheck-github-actions@e3cd8e9aec4587ec73bc0e60745aafd45c37aa2e
         with:
           config_path: .spellcheck-es.yaml
 
       # rojopolis/spellcheck-github-actions does not support PT-BR,
       # only PT, and PT-BR is too different to pass a PT spellcheck
       - name: Set up Python for PT-BR
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.10'
 
@@ -93,10 +93,10 @@ jobs:
     needs: [md_linter, spell_checker]
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
@@ -127,10 +127,10 @@ jobs:
     needs: [md_linter, spell_checker]
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
@@ -150,7 +150,7 @@ jobs:
         run: mkdocs build --config-file mkdocs-pdf-en.yaml
 
       - name: Upload EN PDF
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: pdf-export-en
           path: site/OWASP_Developer_Guide.pdf
@@ -159,7 +159,7 @@ jobs:
         run: mkdocs build --config-file mkdocs-pdf-es.yaml
 
       - name: Upload ES PDF
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: pdf-export-es
           path: site/OWASP_Developer_Guide-ES.pdf
@@ -168,7 +168,7 @@ jobs:
         run: mkdocs build --config-file mkdocs-pdf-fa.yaml
 
       - name: Upload FA PDF
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: pdf-export-fa
           path: site/OWASP_Developer_Guide-FA.pdf
@@ -177,7 +177,7 @@ jobs:
         run: mkdocs build --config-file mkdocs-pdf-pt-br.yaml
 
       - name: Upload PT-BR PDF
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: pdf-export-pt-br
           path: site/OWASP_Developer_Guide-PT-BR.pdf

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Delete stale workflow runs
-        uses: Mattraks/delete-workflow-runs@v2.1.0
+        uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -25,7 +25,7 @@ jobs:
           keep_minimum_runs: 10
 
       - name: Delete unused workflows
-        uses: otto-de/purge-deprecated-workflow-runs@v4.0.4
+        uses: otto-de/purge-deprecated-workflow-runs@f586d3fe7f959c38ca76a0030521dfa47946bce3
         with:
           token: ${{ github.token }}
 
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           # skip the jekyll files under '_includes' directory, check all other directories
           args: >-
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Tidy stale PRs and issues
-        uses: actions/stale@v10.2.0
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:
           days-before-issue-stale: 183
           days-before-issue-close: -1

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -7,7 +7,7 @@ on:
     - cron: '15 6 * * *'
   workflow_dispatch:
 
-# for security reasons the github actions are pinned to specific release versions
+# for security reasons the github actions are pinned to specific SHAs
 jobs:
   chores:
     name: Tidy workflows
@@ -41,6 +41,7 @@ jobs:
         with:
           # skip the jekyll files under '_includes' directory, check all other directories
           args: >-
+            --verbose
             --no-progress
             --max-retries 1
             --retry-wait-time 10

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: >-
             --exclude 'github\.com/OWASP/DevGuide/blob/main/docs'
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Lint markdown
-        uses: DavidAnson/markdownlint-cli2-action@v22.0.0
+        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
         with:
           config: '.markdownlint.yaml'
           globs: |
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Spell check EN language
-        uses: rojopolis/spellcheck-github-actions@0.58.0
+        uses: rojopolis/spellcheck-github-actions@e3cd8e9aec4587ec73bc0e60745aafd45c37aa2e
         with:
           config_path: .spellcheck-en.yaml
 
@@ -64,10 +64,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Spell check ES language
-        uses: rojopolis/spellcheck-github-actions@0.58.0
+        uses: rojopolis/spellcheck-github-actions@e3cd8e9aec4587ec73bc0e60745aafd45c37aa2e
         with:
           config_path: .spellcheck-es.yaml
 
@@ -76,12 +76,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # rojopolis/spellcheck-github-actions does not support PT-BR,
       # only PT, and PT-BR is too different to pass a PT spellcheck
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.10'
 
@@ -101,10 +101,10 @@ jobs:
     needs: [md_linter, spell_checker_en, spell_checker_es, spell_checker_pt-br]
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
@@ -132,10 +132,10 @@ jobs:
     needs: [build_check]
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,7 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-# for security reasons the github actions are pinned to specific release versions
+# for security reasons the github actions are pinned to specific SHAs
 jobs:
   link_checker:
     name: Link checker
@@ -20,6 +20,7 @@ jobs:
         with:
           args: >-
             --exclude 'github\.com/OWASP/DevGuide/blob/main/docs'
+            --verbose
             --no-progress
             --max-retries 1
             --retry-wait-time 10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
       - ?.?.?*
   workflow_dispatch:
 
-# for security reasons the github actions are pinned to specific release versions
+# for security reasons the github actions are pinned to specific SHAs
 jobs:
   export_pdf:
     name: Export PDF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
@@ -35,7 +35,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload PDF
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: 'pdf-export'
           path: 'site/OWASP_Developer_Guide.pdf'
@@ -46,10 +46,10 @@ jobs:
     needs: [export_pdf]
     steps:
       - name: Check out
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Fetch prepared SBOM artifacts
-        uses: actions/download-artifact@v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: 'pdf-export'
           path: 'site/OWASP_Developer_Guide.pdf'
@@ -60,7 +60,7 @@ jobs:
           sed -e s/x.x.x/${releaseVersion:1}/g .release-note-template.md > ./release-notes.txt
 
       - name: Create release notes
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
         with:
           draft: true
           name: "${releaseVersion:1}"

--- a/.wordlist-en.txt
+++ b/.wordlist-en.txt
@@ -3,6 +3,7 @@ AEAD
 AES
 APIT
 APIs
+APISIX
 APK
 ARP
 ASVS
@@ -310,6 +311,7 @@ Threagile
 ThreatAtlas
 Tink
 ToC
+Traefik
 Trivy
 TrustWave
 UEFI

--- a/docs/en/07-training-education/05-top-ten.md
+++ b/docs/en/07-training-education/05-top-ten.md
@@ -4,6 +4,7 @@ The OWASP Top 10 is a standard awareness document for developers and web applica
 It represents a broad consensus about the most critical security risks to web applications.
 
 The OWASP Top Ten is a flagship documentation project and is one of the very first OWASP projects.
+It is actively maintained by a dedicated project team.
 
 #### What is the OWASP Top 10?
 
@@ -12,21 +13,17 @@ within the security community, achieving wide spread acceptance and fame soon af
 Often referred to as just the 'OWASP Top Ten', it is a list that identifies the most important threats
 to web applications and seeks to rank them in importance and severity.
 
-The OWASP Top 10 is periodically revised to keep it up to date with the latest threat landscape.
-The latest version was released in 2021 to mark twenty years of OWASP:
+* [A01:2025][a01] Broken Access Control
+* [A02:2025][a02] Security Misconfiguration
+* [A03:2025][a03] Software Supply Chain Failures
+* [A04:2025][a04] Cryptographic Failures
+* [A05:2025][a05] Injection
+* [A06:2025][a06] Insecure Design
+* [A07:2025][a07] Authentication Failures
+* [A08:2025][a08] Software or Data Integrity Failures
+* [A09:2025][a09] Security Logging and Alerting Failures
+* [A10:2025][a10] Mishandling of Exceptional Conditions
 
-* [A01:2021-Broken Access Control][a01]
-* [A02:2021-Cryptographic Failures][a02]
-* [A03:2021-Injection][a03]
-* [A04:2021-Insecure Design][a04]
-* [A05:2021-Security Misconfiguration][a05]
-* [A06:2021-Vulnerable and Outdated Components][a06]
-* [A07:2021-Identification and Authentication Failures][a07]
-* [A08:2021-Software and Data Integrity Failures][a08]
-* [A09:2021-Security Logging and Monitoring Failures][a09]
-* [A10:2021-Server-Side Request Forgery][a10]
-
-The project itself is actively maintained by a project team.
 The list is [based on data][top10data] collected from identified application vulnerabilities and from a variety of sources;
 security vendors and consultancies, bug bounties, along with company/organizational contributions.
 The data is normalized to allow for level comparison between 'Human assisted Tooling and Tooling assisted Humans'.
@@ -46,33 +43,37 @@ The OWASP Spotlight series provides an overview of the Top Ten: 'Project 10 - [T
 #### OWASP Top 10 versions
 
 The OWASP Top 10 Web Application Security Risks document was originally published in 2003,
-making it one of (or even the most) longest lived OWASP project,
-and since then has been in active and continuous development.
-Listed below are the versions up to the latest in 2021, which was released to mark 20 years of OWASP.
+making it one of (or even the most) longest lived OWASP project.
 
-* Original [2003](https://github.com/OWASP/Top10/blob/master/archives/OWASPWebApplicationSecurityTopTen-Version1.pdf)
-* Update [2004](https://github.com/OWASP/Top10/blob/master/archives/OWASP_Top_Ten_2004.pdf)
-* Update [2007](https://owasp.org/www-pdf-archive//OWASP_Top_10_2007.pdf)
-* Release [2010](https://github.com/OWASP/OWASP-Top-10/tree/master/2010)
+The project is periodically revised to keep it up to date with the latest threat landscape.
+Listed are the versions up to the latest in 2025:
+
+* Original [2003](https://github.com/OWASP/Top10/blob/master/2003/OWASPWebApplicationSecurityTopTen-Version1.pdf)
+* Update [2004](https://github.com/OWASP/Top10/blob/master/2004/OWASP_Top_Ten_2004.pdf)
+* Update [2007](https://github.com/OWASP/Top10/blob/master/2007/OWASP%20Top%2010%202007.pdf)
+* Release [2010](https://github.com/OWASP/Top10/tree/master/2010)
 * Release [2013](https://github.com/OWASP/Top10/tree/master/2013)
 * Release [2017](https://github.com/OWASP/Top10/tree/master/2017)
-* Latest version [2021](https://github.com/OWASP/Top10/tree/master/2021)
+* Release [2021](https://github.com/OWASP/Top10/tree/master/2021)
+* Latest version [2025](https://github.com/OWASP/Top10/tree/master/2025)
+
+The 2021 version of the OWASP Top Ten was released to mark 20 years of OWASP.
 
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
 then [submit an issue][issue0905] or [edit on GitHub][edit0905].
 
-[a01]: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-[a02]: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
-[a03]: https://owasp.org/Top10/A03_2021-Injection/
-[a04]: https://owasp.org/Top10/A04_2021-Insecure_Design/
-[a05]: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-[a06]: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
-[a07]: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/
-[a08]: https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/
-[a09]: https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/
-[a10]: https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/
+[a01]: https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/
+[a02]: https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/
+[a03]: https://owasp.org/Top10/2025/A03_2025-Software_Supply_Chain_Failures/
+[a04]: https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/
+[a05]: https://owasp.org/Top10/2025/A05_2025-Injection/
+[a06]: https://owasp.org/Top10/2025/A06_2025-Insecure_Design/
+[a07]: https://owasp.org/Top10/2025/A07_2025-Authentication_Failures/
+[a08]: https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/
+[a09]: https://owasp.org/Top10/2025/A09_2025-Security_Logging_and_Alerting_Failures/
+[a10]: https://owasp.org/Top10/2025/A10_2025-Mishandling_of_Exceptional_Conditions/
 [edit0905]: https://github.com/OWASP/DevGuide/blob/main/docs/en/07-training-education/05-top-ten.md
 [issue0905]: https://github.com/OWASP/DevGuide/issues/new?labels=content&template=request.md&title=Update:%2007-training-education/05-top-ten
 [spotlight10]: https://youtu.be/RMkoIrpz8ug

--- a/docs/en/09-operations/02-coraza.md
+++ b/docs/en/09-operations/02-coraza.md
@@ -1,14 +1,14 @@
 ![Coraza logo](../../assets/images/logos/coraza.png "OWASP Coraza"){ align=right width=300 }
 
 The [OWASP Coraza][coraza-project] project provides a golang enterprise-grade Web Application Firewall framework
-that supports the [ModSecurity][modsec] seclang language and is completely compatible with OWASP [CRS][crs].
+that supports the [ModSecurity][modsec] seclang language and is completely compatible with OWASP [Core Rule Set][crs] (CRS).
 Coraza is in active development as an OWASP Production code project,
 with the first stable version released in September 2021 and several releases since then.
 
 #### What is Coraza?
 
 The [Coraza][coraza] Web Application Firewall framework is used to enforce policies,
-providing a first line of defense to stop attack on web applications and servers.
+providing a first line of defense to stop attacks on web applications and servers.
 Coraza  can be configured using the OWASP [CRS][crs] and also custom policies can be created.
 
 Coraza can be deployed:
@@ -29,16 +29,19 @@ along with the original OWASP [ModSecurity][modsec] WAF.
 The best way to start is to create a Coraza WAF instance and then add rules to this WAF,
 following the Coraza [Quick Start tutorial][coraza-tutorial].
 
-There are multiple ways of running Coraza, and the one chosen will depend on an individual organization's deployment:
+There are multiple ways of running Coraza, the one chosen will depend on
+the individual organization's deployment and existing infrastructure:
 
 * Coraza [SPOA connector][coraza-spoa] runs the Coraza WAF as a backing service for HAProxy
 * Coraza [Caddy Module][coraza-caddy] provides Web Application Firewall capabilities for Caddy
 * the Coraza [Proxy WASM][coraza-wasm] filter can be loaded directly from Envoy or used as an Istio plugin
-* Coraza as a [C library][coraza-lib], used for applications written in C rather than golang
+* Coraza as a [C library][coraza-lib], used for applications written in C/C++ rather than golang
+* Coraza for [NGINX][nginx], Apache [APISIX][apisix], [Traefik][traefik] and [Envoy][envoy]
 
 #### References
 
 * OWASP [Coraza][coraza]
+* Infrastructure specific Coraza [Connectors][connectors]
 * OWASP [CRS][crs]
 * OWASP [ModSecurity][modsec]
 * [Secure Cloud Architecture][cscloud] cheat sheet
@@ -48,15 +51,20 @@ There are multiple ways of running Coraza, and the one chosen will depend on an 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
 then [submit an issue][issue1102] or [edit on GitHub][edit1102].
 
+[apisix]: https://github.com/corazawaf/coraza-proxy-wasm
+[connectors]: https://www.coraza.io/connectors/
 [coraza]: https://coraza.io/
 [coraza-caddy]: https://github.com/corazawaf/coraza-caddy
 [coraza-lib]: https://github.com/corazawaf/libcoraza
 [coraza-project]: https://owasp.org/www-project-coraza-web-application-firewall/
-[coraza-spoa]: https://coraza.io/connectors/coraza-spoa/
+[coraza-spoa]: https://github.com/corazawaf/coraza-spoa
 [coraza-tutorial]: https://coraza.io/docs/tutorials/quick-start/
 [coraza-wasm]: https://github.com/corazawaf/coraza-proxy-wasm
 [cscloud]: https://cheatsheetseries.owasp.org/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet
 [edit1102]: https://github.com/OWASP/DevGuide/blob/main/docs/en/09-operations/02-coraza.md
+[envoy]: https://github.com/united-security-providers/coraza-envoy-go-filter
 [issue1102]: https://github.com/OWASP/DevGuide/issues/new?labels=content&template=request.md&title=Update:%2009-operations/02-coraza
 [crs]: https://coreruleset.org/
 [modsec]: https://owasp.org/www-project-modsecurity/
+[nginx]: https://github.com/corazawaf/coraza-nginx
+[traefik]: https://github.com/jcchavezs/coraza-http-wasm-traefik

--- a/docs/en/09-operations/02-coraza.md
+++ b/docs/en/09-operations/02-coraza.md
@@ -53,12 +53,12 @@ then [submit an issue][issue1102] or [edit on GitHub][edit1102].
 
 [apisix]: https://github.com/corazawaf/coraza-proxy-wasm
 [connectors]: https://www.coraza.io/connectors/
-[coraza]: https://coraza.io/
+[coraza]: https://www.coraza.io/
 [coraza-caddy]: https://github.com/corazawaf/coraza-caddy
 [coraza-lib]: https://github.com/corazawaf/libcoraza
 [coraza-project]: https://owasp.org/www-project-coraza-web-application-firewall/
 [coraza-spoa]: https://github.com/corazawaf/coraza-spoa
-[coraza-tutorial]: https://coraza.io/docs/tutorials/quick-start/
+[coraza-tutorial]: https://www.coraza.io/docs/tutorials/quick-start/
 [coraza-wasm]: https://github.com/corazawaf/coraza-proxy-wasm
 [cscloud]: https://cheatsheetseries.owasp.org/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet
 [edit1102]: https://github.com/OWASP/DevGuide/blob/main/docs/en/09-operations/02-coraza.md


### PR DESCRIPTION
**Summary** :  

update various dependencies in workflow actions
There was a recent high profile supply chain attack against `aquasecurity/trivy-action` which was successful.
therefore github actions need to be pinned to digests rather than versions

**Description for the changelog**:  

update automation dependencies to use digests

**Declaration**:

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info** :  

Closes #194 
