### PR TITLE
Enable heading permalinks with unicode-aware TOC slugs

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -41,6 +41,9 @@ markdown_extensions:
   - def_list
   - attr_list
   - md_in_html
+  - toc:
+      permalink: true
+      slugify: !!python/name:markdown.extensions.toc.slugify_unicode
 
 plugins:
   - open-in-new-tab  


### PR DESCRIPTION
**Summary** :  

Enable heading permalinks with unicode-aware TOC slugs.
Add toc.permalink so readers can copy deep links to subsections, and use
slugify_unicode so non-Latin headings get stable readable anchors instead of #_1 fallbacks.

**Description for the changelog** :  

Enable heading permalinks with unicode-aware TOC slugs
<!--
A short (one line) summary that describes the changes in this pull request
for inclusion in the change log
-->

**Declaration**:

Thanks for submitting a pull request, please make sure:  

- [ ] content meets the [license](../blob/main/license.txt) for this project
- [ ] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: I used AI to develop the solution and summarize changes into the commit description